### PR TITLE
Clean up merged_statuscake_uptime_tests

### DIFF
--- a/roles/statuscake_monitoring/defaults/main.yml
+++ b/roles/statuscake_monitoring/defaults/main.yml
@@ -2,3 +2,4 @@ statuscake_api_key: ""
 statuscake_default_check_rate: 300
 statuscake_default_test_type: HTTP
 statuscake_uptime_tests: []
+statuscake_merged_uptime_tests: []

--- a/roles/statuscake_monitoring/tasks/main.yml
+++ b/roles/statuscake_monitoring/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Merge statuscake_uptime_tests with templates
   set_fact:
-    merged_statuscake_uptime_tests: "{{ (merged_statuscake_uptime_tests | default([])) + [ item['template'] | default([]) | combine(item) ] }}"
+    statuscake_merged_uptime_tests: "{{ (statuscake_merged_uptime_tests | default([])) + [ item['template'] | default({}) | combine(item) ] }}"
   loop: "{{ statuscake_uptime_tests }}"
   loop_control:
     label: "{{ item['name'] }}"
@@ -20,10 +20,10 @@
     final_endpoint: "{{ item['final_endpoint']|default(omit) }}"
     follow_redirects: "{{ item['follow_redirects']|default(omit) }}"
     log_file: "{{ item['log_file']|default(omit) }}"
-  loop: "{{ merged_statuscake_uptime_tests }}"
+  loop: "{{ statuscake_merged_uptime_tests }}"
   loop_control:
     label: "{{ item['name'] }}"
 
-- name: Clean up variables
+- name: Clean up StatusCake variables
   set_fact:
-    merged_statuscake_uptime_tests: []
+    statuscake_merged_uptime_tests: []

--- a/roles/statuscake_monitoring/tasks/main.yml
+++ b/roles/statuscake_monitoring/tasks/main.yml
@@ -23,3 +23,7 @@
   loop: "{{ merged_statuscake_uptime_tests }}"
   loop_control:
     label: "{{ item['name'] }}"
+
+- name: Clean up variables
+  set_fact:
+    merged_statuscake_uptime_tests: []


### PR DESCRIPTION
So the role can easily be reused without resetting variables.