### PR TITLE
Update StatusCake list parameter encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,19 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
-    hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
-    -   id: check-added-large-files
-
--   repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
-    -   id: black
+      - id: black
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        exclude: settings|migrations|tests
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -9,6 +9,7 @@ import http.client
 logger = logging.getLogger("statuscake")
 httpclient_logger = logging.getLogger("http.client")
 
+
 def httpclient_logging_patch(level=logging.DEBUG):
     """
     Enable HTTPConnection debug logging to the logging framework, so that

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -218,7 +218,9 @@ class UptimeTest(StatusCakeAPI):
 class SSLTest(StatusCakeAPI):
 
     url = "/v1/ssl"
-    CSV_PARAMETERS = ("alert_at", "contact_groups")
+    # API parameters to modify when sending lists to StatusCake
+    # For exaple, alert_at=[1, 2] becomes alert_at[]=1&alert_at[]=2
+    LIST_PARAMETERS = ("alert_at", "contact_groups")
 
     def fetch_all(self):
         """
@@ -242,13 +244,9 @@ class SSLTest(StatusCakeAPI):
 
     def prepare_data(self, data):
         data = super().prepare_data(data)
-        for key in self.CSV_PARAMETERS:
+        for key in self.LIST_PARAMETERS:
             if key in data:
-                key_csv = f"{key}_csv"
-                item = [str(_val) for _val in data[key]]
-                item_csv = ",".join(item)
-                data[key_csv] = item_csv
-                data.pop(key)
+                data[f"{key}[]"] = data.pop(key)
         if not data["website_url"].endswith("/"):
             data["website_url"] = data["website_url"] + "/"
         return data

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -54,6 +54,7 @@ class StatusCakeAPI:
     CSV_PARAMETERS = set()
     # API parameters to modify when sending lists to StatusCake
     # For exaple, tags=["prod", "myteam"] becomes tags[]=prod&tags[]=myteam
+    # See: https://developers.statuscake.com/guides/api/parameters/
     LIST_PARAMETERS = set()
 
     def __init__(self, api_key, state, log_file=None, **kwargs) -> None:
@@ -115,12 +116,12 @@ class StatusCakeAPI:
 class UptimeTest(StatusCakeAPI):
 
     url = "/v1/uptime"
-    CSV_PARAMETERS = (
-        "tags",
+    CSV_PARAMETERS = ("status_codes",)
+    LIST_PARAMETERS = (
         "contact_groups",
         "dns_ip",
+        "tags",
     )
-    LIST_PARAMETERS = ("status_codes",)
 
     def fetch_all(self):
         self._request("get", self.url, params={"page": 1, "limit": 100})

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -103,7 +103,7 @@ class StatusCakeAPI:
         self.response = response
         if self.response.status_code < 200 or self.response.status_code >= 300:
             data = self.response.json()
-            msg = f"StatusCake error: {data.get('message')} - {data.get('errors')} --- Request data: {kwargs.get('data')}"
+            msg = f"StatusCake error: {data.get('message')} - {data.get('errors')} --- Request data: {kwargs.get('data')}"  # noqa
             logger.error(msg)
             self.status.message = msg
             # mark as failed so error is sent to Ansible output
@@ -181,7 +181,7 @@ class UptimeTest(StatusCakeAPI):
                 ] or fetch_tests["test_type"] != self.config.get("test_type", "HTTP"):
                     self.status.success = False
                     self.status.changed = False
-                    msg = f"You attempted to change {fetch_tests['name']}'s 'website_url' or 'test_type' - they are immutable. To successfuly change them, delete the current test and create a new uptime test with the new parameters."
+                    msg = f"You attempted to change {fetch_tests['name']}'s 'website_url' or 'test_type' - they are immutable. To successfuly change them, delete the current test and create a new uptime test with the new parameters."  # noqa
                     logger.info(msg)
                     self.status.message = msg
                     return

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -95,8 +95,6 @@ class StatusCakeAPI:
 
     def _request(self, method, path, **kwargs):
         requests_method = getattr(self.client, method)
-        logger.debug(f"CSV_PARAMETERS: {self.CSV_PARAMETERS}")
-        logger.debug(f"LIST_PARAMETERS: {self.LIST_PARAMETERS}")
         try:
             logger.debug(f"Request data: {kwargs['data']}")
         except KeyError:

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -102,7 +102,11 @@ class StatusCakeAPI:
         response = requests_method(self.full_url(path), **kwargs)
         self.response = response
         if self.response.status_code < 200 or self.response.status_code >= 300:
-            data = self.response.json()
+            data = {"message": response.reason, "errors": ""}
+            try:
+                data = self.response.json()
+            except requests.JSONDecodeError:
+                data["errors"] = response.headers
             msg = f"StatusCake error: {data.get('message')} - {data.get('errors')} --- Request data: {kwargs.get('data')}"  # noqa
             logger.error(msg)
             self.status.message = msg

--- a/plugins/module_utils/statuscake.py
+++ b/plugins/module_utils/statuscake.py
@@ -62,6 +62,13 @@ class StatusCakeAPI:
             pass
         response = requests_method(self.full_url(path), **kwargs)
         self.response = response
+        if self.response.status_code < 200 or self.response.status_code >= 300:
+            data = self.response.json()
+            msg = f"StatusCake error: {data.get('message')} - {data.get('errors')} --- Request data: {kwargs.get('data')}"
+            logger.error(msg)
+            self.status.message = msg
+            # mark as failed so error is sent to Ansible output
+            self.status.success = False
         return response
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+testpaths = [ "tests" ]
+pythonpath = [ "." ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==6.0
 requests==2.26.0
 urllib3==1.26.7
 ansible==5.1.0
+pytest==7.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.26.0
 urllib3==1.26.7
 ansible==5.1.0
 pytest==7.2.0
+requests-mock==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pre-commit==2.16.0
 PyYAML==6.0
-requests==2.26.0
+requests==2.28.1
 urllib3==1.26.7
 ansible==5.1.0
 pytest==7.2.0

--- a/roles/statuscake_monitoring/defaults/main.yml
+++ b/roles/statuscake_monitoring/defaults/main.yml
@@ -41,7 +41,7 @@ statuscake_ssl_follow_redirects: False
 statuscake_ssl_check_rate: 86400
 statuscake_ssl_contact_groups: "{{ statuscake_contact_groups }}"
 statuscake_ssl_hostname: null
-statuscake_ssl_log_file: ""
+statuscake_ssl_log_file: "{{ statuscake_log_file }}"
 statuscake_ssl_paused: "{{ statuscake_paused }}"
 statuscake_ssl_state: "{{ statuscake_state }}"
 statuscake_ssl_user_agent: ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[flake8]
+# not sure why this needs to be more the Black's line length..
+max-line-length = 101
+ignore=
+    # F405: 'xxxx' may be undefined, or defined from star imports:
+    F405,
+    # W503 line break before binary operator
+    W503,
+    # E731 do not assign a lambda expression, use a def
+    E731,
+    # E203 not PEP8, per Black
+    E203,
+    # E722 do not use bare 'except'
+    E722

--- a/tests/module_utils/test_statuscake.py
+++ b/tests/module_utils/test_statuscake.py
@@ -1,6 +1,14 @@
 from plugins.module_utils import statuscake
 
 
+class TestStatusCakeAPI:
+    def test_failed_status_code_api_call(self, requests_mock):
+        requests_mock.get("/v1/uptime", status_code=400, json={"message": "Bad Error"})
+        client = statuscake.StatusCakeAPI(api_key="", state="")
+        client._request("get", "/v1/uptime")
+        assert "Bad Error" in client.status.message
+
+
 class TestUptimeTest:
     def test_contact_groups(self):
         client = statuscake.UptimeTest(

--- a/tests/module_utils/test_statuscake.py
+++ b/tests/module_utils/test_statuscake.py
@@ -1,0 +1,43 @@
+from plugins.module_utils import statuscake
+
+
+class TestUptimeTest:
+    def test_contact_groups(self):
+        client = statuscake.UptimeTest(
+            api_key="", state="", contact_groups=[100000, 110000]
+        )
+        assert client.config == {"contact_groups[]": [100000, 110000]}
+
+    def test_status_codes_csv(self):
+        client = statuscake.UptimeTest(api_key="", state="", status_codes=[200, 201])
+        assert client.config == {"status_codes_csv": "200,201"}
+
+    def test_tags(self):
+        client = statuscake.UptimeTest(api_key="", state="", tags=["prod"])
+        assert client.config == {"tags[]": ["prod"]}
+
+
+class TestSSLTest:
+    def test_alert_at(self):
+        client = statuscake.SSLTest(
+            api_key="",
+            state="",
+            website_url="https://example.com/",
+            alert_at=[10, 20, 30],
+        )
+        assert client.config == {
+            "website_url": "https://example.com/",
+            "alert_at[]": [10, 20, 30],
+        }
+
+    def test_contact_groups(self):
+        client = statuscake.SSLTest(
+            api_key="",
+            state="",
+            website_url="https://example.com/",
+            contact_groups=[100000, 110000],
+        )
+        assert client.config == {
+            "website_url": "https://example.com/",
+            "contact_groups[]": [100000, 110000],
+        }

--- a/tests/module_utils/test_statuscake.py
+++ b/tests/module_utils/test_statuscake.py
@@ -2,6 +2,12 @@ from plugins.module_utils import statuscake
 
 
 class TestStatusCakeAPI:
+    def test_too_many_requests_api_call(self, requests_mock):
+        requests_mock.get("/v1/uptime", status_code=429, reason="Too Many Requests")
+        client = statuscake.StatusCakeAPI(api_key="", state="")
+        client._request("get", "/v1/uptime")
+        assert "Too Many Requests" in client.status.message
+
     def test_failed_status_code_api_call(self, requests_mock):
         requests_mock.get("/v1/uptime", status_code=400, json={"message": "Bad Error"})
         client = statuscake.StatusCakeAPI(api_key="", state="")


### PR DESCRIPTION
The StatusCake API changed how most list parameters (**but not status_codes** 😩 ) must be encoded. `urllib.parse.urlencode`'s default with [doseq=True](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode) doesn't work, since the API expects square brackets for each value.

Summary:
- Add `LIST_PARAMETERS` to encode as `myvar[]`
- Still support `CSV_PARAMETERS` with `status_codes` (which becomes `status_codes_csv`)
- If StatusCake API status code isn't 2xx, return error message to Ansible for output
- Add requests logging patch to capture headers and POST body when debugging
- Add initial unit tests
- Add test GitHub action workflow

For example, the docs using `alert_at`:

```
curl -X POST https://api.statuscake.com/v1/ssl \
  -H "Authorization: Bearer ${API_TOKEN}" \
  -d "website_url=https://www.example.com&check_rate=1800&alert_at[]=1&alert_at[]=2&alert_at[]=3&alert_reminder=true&alert_expiry=true&alert_broken=true&alert_mixed=true"
```


Failing headers, POST body, and error:

```
2022-12-06 12:21:06,235 urllib3.connectionpool DEBUG    Starting new HTTPS connection (1): api.statuscake.com:443
2022-12-06 12:21:06,493 http.client            DEBUG    send: b'GET /v1/ssl?page=1&limit=100 HTTP/1.1\r\nHost: api.statuscake.com\r\nUser-Agent: python-requests/2.27.1\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nAuthorization: Bearer ***\r\n\r\n'
2022-12-06 12:21:07,002 http.client            DEBUG    reply: 'HTTP/1.1 200 OK\r\n'
2022-12-06 12:21:07,003 http.client            DEBUG    header: content-type: application/json
2022-12-06 12:21:07,003 http.client            DEBUG    header: date: Tue, 06 Dec 2022 17:21:06 GMT
2022-12-06 12:21:07,003 http.client            DEBUG    header: server: istio-envoy
2022-12-06 12:21:07,003 http.client            DEBUG    header: x-envoy-upstream-service-time: 304
2022-12-06 12:21:07,003 http.client            DEBUG    header: x-ratelimit-limit: 5, 5;w=1
2022-12-06 12:21:07,003 http.client            DEBUG    header: x-ratelimit-remaining: 4
2022-12-06 12:21:07,003 http.client            DEBUG    header: x-ratelimit-reset: 1
2022-12-06 12:21:07,003 http.client            DEBUG    header: transfer-encoding: chunked
2022-12-06 12:21:07,003 urllib3.connectionpool DEBUG    https://api.statuscake.com:443 "GET /v1/ssl?page=1&limit=100 HTTP/1.1" 200 None
2022-12-06 12:21:07,004 statuscake             INFO     Does 'https://***.com/' exist in StatusCake? False.
2022-12-06 12:21:07,007 http.client            DEBUG    send: b'POST /v1/ssl HTTP/1.1\r\nHost: api.statuscake.com\r\nUser-Agent: python-requests/2.27.1\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nAuthorization: Bearer ***\r\nContent-Length: 233\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n'
2022-12-06 12:21:07,008 http.client            DEBUG    send: b'website_url=https%3A%2F%2F***.com%2F&check_rate=86400&contact_groups=109246&contact_groups=90744&contact_groups=250314&alert_at=28&alert_at=7&alert_at=1&alert_reminder=True&alert_expiry=True&alert_broken=True&alert_mixed=True'
2022-12-06 12:21:07,211 http.client            DEBUG    reply: 'HTTP/1.1 400 Bad Request\r\n'
2022-12-06 12:21:07,212 http.client            DEBUG    header: content-type: application/json
2022-12-06 12:21:07,212 http.client            DEBUG    header: content-length: 249
2022-12-06 12:21:07,212 http.client            DEBUG    header: date: Tue, 06 Dec 2022 17:21:07 GMT
2022-12-06 12:21:07,212 http.client            DEBUG    header: server: istio-envoy
2022-12-06 12:21:07,212 http.client            DEBUG    header: x-envoy-upstream-service-time: 42
2022-12-06 12:21:07,212 http.client            DEBUG    header: x-ratelimit-limit: 5, 5;w=1
2022-12-06 12:21:07,212 http.client            DEBUG    header: x-ratelimit-remaining: 4
2022-12-06 12:21:07,212 http.client            DEBUG    header: x-ratelimit-reset: 1
2022-12-06 12:21:07,213 urllib3.connectionpool DEBUG    https://api.statuscake.com:443 "POST /v1/ssl HTTP/1.1" 400 249
2022-12-06 12:21:07,214 statuscake             ERROR    StatusCake error: https://api.statuscake.com/v1/ssl The provided parameters are invalid. Check the errors output for detailed information. {'alert_at': ['Alert At Invalid', 'Alert At requires exactly 3 unique, positive integer values'], 'contact_groups': ['Contact Groups Invalid']} --- Request data: {'website_url': 'https://***.com/', 'check_rate': 86400, 'contact_groups': [109246, 90744, 250314], 'alert_at': [28, 7, 1], 'alert_reminder': True, 'alert_expiry': True, 'alert_broken': True, 'alert_mixed': True} None
```

Success headers, POST body, and error:

```
2022-12-06 12:29:39,360 urllib3.connectionpool DEBUG    Starting new HTTPS connection (1): api.statuscake.com:443
2022-12-06 12:29:39,591 http.client            DEBUG    send: b'GET /v1/ssl?page=1&limit=100 HTTP/1.1\r\nHost: api.statuscake.com\r\nUser-Agent: python-requests/2.27.1\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nAuthorization: Bearer ***\r\n\r\n'
2022-12-06 12:29:40,203 http.client            DEBUG    reply: 'HTTP/1.1 200 OK\r\n'
2022-12-06 12:29:40,204 http.client            DEBUG    header: content-type: application/json
2022-12-06 12:29:40,204 http.client            DEBUG    header: date: Tue, 06 Dec 2022 17:29:39 GMT
2022-12-06 12:29:40,204 http.client            DEBUG    header: server: istio-envoy
2022-12-06 12:29:40,204 http.client            DEBUG    header: x-envoy-upstream-service-time: 331
2022-12-06 12:29:40,204 http.client            DEBUG    header: x-ratelimit-limit: 5, 5;w=1
2022-12-06 12:29:40,204 http.client            DEBUG    header: x-ratelimit-remaining: 4
2022-12-06 12:29:40,204 http.client            DEBUG    header: x-ratelimit-reset: 1
2022-12-06 12:29:40,204 http.client            DEBUG    header: transfer-encoding: chunked
2022-12-06 12:29:40,205 urllib3.connectionpool DEBUG    https://api.statuscake.com:443 "GET /v1/ssl?page=1&limit=100 HTTP/1.1" 200 None
2022-12-06 12:29:40,211 statuscake             INFO     Does 'https://***.com/' exist in StatusCake? False.
2022-12-06 12:29:40,215 http.client            DEBUG    send: b'POST /v1/ssl HTTP/1.1\r\nHost: api.statuscake.com\r\nUser-Agent: python-requests/2.27.1\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nAuthorization: Bearer ***\r\nContent-Length: 269\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n'
2022-12-06 12:29:40,215 http.client            DEBUG    send: b'website_url=https%3A%2F%2F***.com%2F&check_rate=86400&alert_reminder=True&alert_expiry=True&alert_broken=True&alert_mixed=True&alert_at%5B%5D=28&alert_at%5B%5D=7&alert_at%5B%5D=1&contact_groups%5B%5D=109246&contact_groups%5B%5D=90744&contact_groups%5B%5D=250314'
2022-12-06 12:29:40,464 http.client            DEBUG    reply: 'HTTP/1.1 201 Created\r\n'
2022-12-06 12:29:40,464 http.client            DEBUG    header: content-type: application/json
2022-12-06 12:29:40,464 http.client            DEBUG    header: content-length: 28
2022-12-06 12:29:40,464 http.client            DEBUG    header: date: Tue, 06 Dec 2022 17:29:40 GMT
2022-12-06 12:29:40,465 http.client            DEBUG    header: server: istio-envoy
2022-12-06 12:29:40,465 http.client            DEBUG    header: x-envoy-upstream-service-time: 143
2022-12-06 12:29:40,465 http.client            DEBUG    header: x-ratelimit-limit: 5, 5;w=1
2022-12-06 12:29:40,465 http.client            DEBUG    header: x-ratelimit-remaining: 4
2022-12-06 12:29:40,465 http.client            DEBUG    header: x-ratelimit-reset: 1
2022-12-06 12:29:40,465 urllib3.connectionpool DEBUG    https://api.statuscake.com:443 "POST /v1/ssl HTTP/1.1" 201 28
2022-12-06 12:29:40,466 statuscake             INFO     A new SSL test for 'https://***.com/' was created.
```