### PR TITLE
Remove get_md5 from reboot task

### DIFF
--- a/roles/os_updates/tasks/main.yml
+++ b/roles/os_updates/tasks/main.yml
@@ -29,7 +29,6 @@
   register: needs_reboot
   stat:
     path: /var/run/
-    get_md5: no
   changed_when: needs_reboot.stat.exists
   when: os_updates_reboot
 


### PR DESCRIPTION
This PR removes `get_md5` allowing nodes to reboot.

This was removed in https://github.com/ansible/ansible/commit/d955fb1590efaaf996d7a48746e15f71cc65f583