### PR TITLE
Add support for `os_updates_reboot_timeout`

### DIFF
--- a/roles/os_updates/defaults/main.yml
+++ b/roles/os_updates/defaults/main.yml
@@ -2,5 +2,6 @@
 aws_profile: ""
 
 os_updates_reboot: false
+# os_updates_reboot_timeout: 600
 os_updates_salt_hold: false
 os_updates_ec2_instances: false

--- a/roles/os_updates/tasks/main.yml
+++ b/roles/os_updates/tasks/main.yml
@@ -39,6 +39,7 @@
 - name: Rebooting
   reboot:
     msg: "rebooting {{ ansible_host }}"
+    reboot_timeout: "{{ os_updates_reboot_timeout | default(omit) }}"
   when: os_updates_reboot and needs_reboot.stat.exists and not os_updates_ec2_instances
 
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-reboot.html


### PR DESCRIPTION
Some servers take longer to reboot, and the ability to change [reboot_timeout](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html#parameter-reboot_timeout) is helpful.