### PR TITLE
Retry `os_updates` tasks prone to failure

### DIFF
--- a/roles/os_updates/defaults/main.yml
+++ b/roles/os_updates/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 aws_profile: ""
 
+os_updates_apt_cache_valid_time: 3600
+os_updates_apt_retries: 5
+os_updates_apt_delay: 3
 os_updates_reboot: false
 # os_updates_reboot_timeout: 600
 os_updates_salt_hold: false

--- a/roles/os_updates/tasks/main.yml
+++ b/roles/os_updates/tasks/main.yml
@@ -11,18 +11,24 @@
 - name: Remove useless packages from the cache
   apt:
     autoclean: yes
+  retries: "{{ os_updates_apt_retries}}"
+  delay: "{{ os_updates_apt_delay }}"
   tags: os_updates
 
 # clean out old kernels to make room in /boot before an upgrade
 - name: Remove dependencies that are no longer required
   apt:
     autoremove: yes
+  retries: "{{ os_updates_apt_retries}}"
+  delay: "{{ os_updates_apt_delay }}"
   tags: os_updates
 
 - name: Run updates
   apt:
     upgrade: dist
-    cache_valid_time: 3600
+    cache_valid_time: "{{ os_updates_apt_cache_valid_time }}"
+  retries: "{{ os_updates_apt_retries}}"
+  delay: "{{ os_updates_apt_delay }}"
   tags: os_updates
 
 - name: Check if a reboot is required


### PR DESCRIPTION
Some apt tasks in the `os_updates` role are prone to failure on some VMs. I think the apt process from the previous task sticks around for a few seconds even after the success is received by Ansible. This seems to work around it, for example:

```
TASK [caktus.hosting_services.os_updates : Remove dependencies that are no longer required] ***
Thursday 09 January 2025  14:08:18 -0500 (0:00:07.784)       0:00:25.391 ****** 
<snip>
FAILED - RETRYING: [db1_testing]: Remove dependencies that are no longer required (5 retries left).
<snip>
ok: [db1_testing]
```

Also, we might as well make `os_updates_apt_cache_valid_time` configurable.