### PR TITLE
Add Cloudwatch Metrics Helm Chart

### DIFF
--- a/roles/eks_cloudwatch_metrics/defaults/main.yml
+++ b/roles/eks_cloudwatch_metrics/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+k8s_aws_cloudwatch_metrics_cluster_name: ""
+
+k8s_aws_cloudwatch_metrics_alarms: ""
+k8s_aws_alarm_actions_arn: ""
+k8s_aws_cloudwatch_alarm_region: "us-east-1"

--- a/roles/eks_cloudwatch_metrics/tasks/main.yml
+++ b/roles/eks_cloudwatch_metrics/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Create Amazon CloudWatch Metrics namespace
+  tags: cloudwatch
+  community.kubernetes.k8s:
+    context: "{{ k8s_context|mandatory }}"
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    name: "{{ k8s_aws_cloudwatch_metrics_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: present
+
+- name: Add AWS CloudWatch Metrics helm chart (monitoring)
+  tags: cloudwatch
+  community.kubernetes.helm:
+    context: "{{ k8s_context|mandatory }}"
+    kubeconfig: "{{ k8s_kubeconfig }}"
+    chart_repo_url: "https://aws.github.io/eks-charts"
+    chart_ref: aws-cloudwatch-metrics
+    # https://artifacthub.io/packages/helm/aws/aws-cloudwatch-metrics
+    chart_version: "{{ k8s_aws_cloudwatch_metrics_chart_version }}"
+    release_name: aws-cloudwatch-metrics
+    release_namespace: "{{ k8s_aws_cloudwatch_metrics_namespace }}"
+    release_values:
+      clusterName: "{{ k8s_aws_cloudwatch_metrics_cluster_name }}"
+    wait: yes
+
+- name: Create alarms
+  tags: cloudwatch
+  amazon.aws.cloudwatch_metric_alarm:
+    state: present
+    region: "{{ k8s_aws_cloudwatch_alarm_region }}"
+    name: "{{ item.name }}"
+    description: "{{ item.description }}"
+    metric: "{{ item.metric }}"
+    namespace: "ContainerInsights"
+    dimensions:
+      ClusterName: "{{ k8s_aws_cloudwatch_metrics_cluster_name }}"
+    statistic: Average
+    comparison: "{{ item.comparison }}"
+    threshold: "{{ item.threshold }}"
+    period: "{{ item.period }}"
+    evaluation_periods: "{{ item.evaluation_periods }}"
+    alarm_actions:
+      - "{{ k8s_aws_alarm_actions_arn }}"
+  loop: "{{ k8s_aws_cloudwatch_metrics_alarms }}"


### PR DESCRIPTION
This PR adds Cloudwatch metrics helm chart to ansible-collection-caktus-hosting-services

FYI: This is the first time I add a new role.

**Question:**
Where can I add the installation and comments?

```
# aws-cloudwatch-metrics:
# - https://github.com/aws/eks-charts/tree/master/stable/aws-cloudwatch-metrics
# - https://artifacthub.io/packages/helm/aws/aws-cloudwatch-metrics
k8s_aws_cloudwatch_metrics_chart_version: "0.0.11"
k8s_aws_cloudwatch_metrics_namespace: amazon-cloudwatch
```

Closes: https://app.clickup.com/t/8685jy6nc