### PR TITLE
Fix path checked for `needs_reboot`

### DIFF
--- a/roles/os_updates/tasks/main.yml
+++ b/roles/os_updates/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Check if a reboot is required
   register: needs_reboot
   stat:
-    path: /var/run/
+    path: /var/run/reboot-required
   changed_when: needs_reboot.stat.exists
   when: os_updates_reboot
 


### PR DESCRIPTION
We're checking the wrong path, so servers are always rebooted.

`/var/run/reboot-required` is the correct path, and that's what's used in the [private version](https://github.com/caktus/caktus-hosting-services/blob/7c7131528fb604bb33c4af749acd8421cd111278/services/roles/os-updates/tasks/main.yml#L29-L35) of this open source role.

See also: https://www.cyberciti.biz/faq/how-to-find-out-if-my-ubuntudebian-linux-server-needs-a-reboot/